### PR TITLE
Add custom 404 handler with tests

### DIFF
--- a/iskcongkp/settings/test.py
+++ b/iskcongkp/settings/test.py
@@ -1,0 +1,14 @@
+from .base import *
+
+DEBUG = False
+
+SECRET_KEY = 'test-secret-key'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+ALLOWED_HOSTS = ['testserver']

--- a/iskcongkp/tests/test_error_handler.py
+++ b/iskcongkp/tests/test_error_handler.py
@@ -1,0 +1,12 @@
+from django.test import SimpleTestCase, override_settings
+
+
+@override_settings(
+    DEBUG=False,
+    DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+)
+class ErrorHandlerTests(SimpleTestCase):
+    def test_custom_404_template_used(self):
+        response = self.client.get('/this-url-does-not-exist/')
+        self.assertEqual(response.status_code, 404)
+        self.assertTemplateUsed(response, '404.html')

--- a/iskcongkp/urls.py
+++ b/iskcongkp/urls.py
@@ -41,3 +41,6 @@ urlpatterns = [
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+# Custom error handlers
+handler404 = 'iskcongkp.views.error_404_view'
+

--- a/iskcongkp/views.py
+++ b/iskcongkp/views.py
@@ -12,4 +12,4 @@ def privacy_view(request):
 def error_404_view(request, exception):
     # we add the path to the 404.html file
     # here. The name of our HTML file is 404.html
-    return render(request, '404.html')
+    return render(request, '404.html', status=404)


### PR DESCRIPTION
## Summary
- customize `handler404`
- return 404 status from custom view
- add test settings module
- ensure the custom 404 page works when DEBUG=False

## Testing
- `ENVIRONMENT_NAME=test python manage.py test iskcongkp.tests.test_error_handler -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6889b101d8b4832db00ef68ee0321be3