### PR TITLE
Add maintenance page and mode

### DIFF
--- a/iskcongkp/middleware.py
+++ b/iskcongkp/middleware.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+class MaintenanceModeMiddleware:
+    """Redirect all requests to the maintenance page when enabled."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if getattr(settings, "MAINTENANCE_MODE", False):
+            maintenance_url = reverse("maintenance")
+            excluded_paths = [maintenance_url, "/admin/"]
+            static_prefix = getattr(settings, "STATIC_URL", "/static/")
+            media_prefix = getattr(settings, "MEDIA_URL", "/media/")
+            if (
+                not request.path.startswith(tuple(excluded_paths))
+                and not request.path.startswith(static_prefix)
+                and not request.path.startswith(media_prefix)
+            ):
+                return redirect(maintenance_url)
+        return self.get_response(request)

--- a/iskcongkp/settings/base.py
+++ b/iskcongkp/settings/base.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'iskcongkp.middleware.MaintenanceModeMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -148,3 +149,4 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Social login Django allauth settings
 SITE_ID = 1
+MAINTENANCE_MODE = False

--- a/iskcongkp/settings/production.py
+++ b/iskcongkp/settings/production.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'iskcongkp.middleware.MaintenanceModeMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -148,3 +149,4 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Social login Django allauth settings
 SITE_ID = 1
+MAINTENANCE_MODE = False

--- a/iskcongkp/urls.py
+++ b/iskcongkp/urls.py
@@ -22,7 +22,7 @@ from django.conf.urls.static import static
 from django.views.static import serve
 
 
-from .views import  contact_view, privacy_view , terms_view
+from .views import  contact_view, privacy_view , terms_view, maintenance_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -34,6 +34,7 @@ urlpatterns = [
     path("contact", contact_view, name="contact"),
     path("terms", terms_view, name="terms"),
     path("privacy-policy", privacy_view, name="privacy-policy"),
+    path("maintenance/", maintenance_view, name="maintenance"),
     url(r'^assets/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT}),
     url(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT})
 

--- a/iskcongkp/views.py
+++ b/iskcongkp/views.py
@@ -9,6 +9,9 @@ def terms_view(request):
 def privacy_view(request):
     return render(request, 'privacy.html')
 
+def maintenance_view(request):
+    return render(request, 'maintenance.html')
+
 def error_404_view(request, exception):
     # we add the path to the 404.html file
     # here. The name of our HTML file is 404.html

--- a/templates/maintenance.html
+++ b/templates/maintenance.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+{% load static %}
+
+<html lang="en" dir="ltr" prefix="og: https://ogp.me/ns#">
+
+<head>
+    {% include 'head.html' %}
+    <title>Maintenance | ISKCON Gorakhpur</title>
+</head>
+
+<body class="layout-no-sidebars path-contact-usk node--type-page">
+    <a href="#main-content" class="visually-hidden-focusable">
+        Skip to main content
+    </a>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5RKQZD47" height="0" width="0"
+            style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+        <div id="page-wrapper">
+            <div id="page">
+                {% include 'navbar.html' %}
+                <div class="highlighted">
+                    <aside class="container section clearfix" role="complementary">
+                        <div data-drupal-messages-fallback class="hidden"></div>
+                    </aside>
+                </div>
+                <div id="main-wrapper" class="layout-main-wrapper clearfix">
+                    <div id="main" class="container">
+
+                        <div class="row row-offcanvas row-offcanvas-left clearfix">
+                            <main class="main-content col" id="content" role="main">
+                                <section class="section">
+                                    <a href="#main-content" id="main-content" tabindex="-1"></a>
+                                    <div id="block-akara-page-title" class="block block-core block-page-title-block">
+                                        <div class="content">
+                                            <h1 class="title"><span
+                                                    class="field field--name-title field--type-string field--label-hidden">Maintenance</span>
+                                            </h1>
+                                        </div>
+                                    </div>
+                                    <div id="block-akara-content" class="block block-system block-system-main-block">
+                                        <div class="content">
+                                            <article role="article"
+                                                class="node node--type-page node--view-mode-full clearfix">
+                                                <div class="node__content clearfix">
+                                                    <div
+                                                        class="clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item">
+                                                        <div class="col-xs-12 col-sm-12 col-md-12"
+                                                            style="display:flex;flex-wrap:wrap;text-align:center;">
+                                                            <div class="col-xs-12 col-sm-12 col-md-6"
+                                                                style="margin:0 auto;">
+                                                                <p class="text-warning fs-2 fw-bold">We'll be back soon!</p>
+                                                                <p>Our site is currently undergoing scheduled maintenance.
+                                                                    Please check back later. Return to <a
+                                                                        href="/"><strong>HOME</strong></a>.</p>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </article>
+                                        </div>
+                                    </div>
+                                </section>
+                            </main>
+                        </div>
+                    </div>
+                </div>
+                {% include 'footer.html' %}
+            </div>
+        </div>
+    </div>
+    {% include 'body_script.html' %}
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add maintenance template and route
- support optional maintenance mode via setting and middleware

## Testing
- `python manage.py test` *(fails: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_6894cdadc244832db9864133dcbe8ad2