### PR TITLE
Show news modal automatically

### DIFF
--- a/templates/body_script.html
+++ b/templates/body_script.html
@@ -186,6 +186,15 @@
 <script src="{% static 'modules/contrib/google_tag/js/8tqr9gtag.js' %}"></script>
 <script src="{% static 'modules/contrib/google_tag/js/s8tqr9gtag.js' %}"></script>
 <script src="{% static 'sites/default/files/js/js_Gp4c7SYx4wl7Wd9mE0s4wseI6GimRuoVwHWJyDftWcY.js' %}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const modalEl = document.getElementById('newsModal');
+    if (modalEl) {
+        const modal = new bootstrap.Modal(modalEl);
+        modal.show();
+    }
+});
+</script>
 <div style="position: static;">
     <div class="a2a_overlay" id="a2a_overlay"></div>
     <div id="a2a_modal" class="a2a_modal a2a_hide" role="dialog" tabindex="-1" aria-label>

--- a/templates/home.html
+++ b/templates/home.html
@@ -269,7 +269,7 @@
         </div>
     </div>
     {% if news_popup %}
-    <div class="modal fade" id="newsPopupModal" tabindex="-1" aria-hidden="true">
+    <div class="modal fade" id="newsModal" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-body p-0">
@@ -280,12 +280,6 @@
         </div>
       </div>
     </div>
-    <script>
-      document.addEventListener('DOMContentLoaded', function () {
-        var modal = new bootstrap.Modal(document.getElementById('newsPopupModal'));
-        modal.show();
-      });
-    </script>
     {% endif %}
     {% include 'body_script.html' %}
 </body>


### PR DESCRIPTION
## Summary
- Display `newsModal` automatically via new DOMContentLoaded script
- Rename popup modal to `newsModal` and remove inline JS

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68aefb1f7cc8832d9e405d62c9beb275