### PR TITLE
Add CSRF tokens to remaining Tula Daan forms

### DIFF
--- a/templates/donation/tula-daan.html
+++ b/templates/donation/tula-daan.html
@@ -409,6 +409,7 @@
                                   <div class="mb-3 mt-3 row">
                                     <form id="myForm" action="" method="POST"
                                       onchange="SetData('wheatflour_seva_amount','Wheat Flour')">
+                                      {% csrf_token %}
                                       <div class="tab-content" id="pills-tabContent">
                                         <div class="tab-pane fade show active" id="pills-wheatflour" role="tabpanel"
                                           aria-labelledby="pills-wheatflour-tab">
@@ -632,6 +633,7 @@
                                   <div class="mb-3 mt-3 row">
                                     <form id="myForm" action="" method="POST"
                                       onchange="SetData('edibleoil_seva_amount','Edible Oil')">
+                                      {% csrf_token %}
                                       <div class="tab-content" id="pills-tabContent">
                                         <div class="tab-pane fade show active" id="pills-edibleoil" role="tabpanel"
                                           aria-labelledby="pills-edibleoil-tab">
@@ -855,6 +857,7 @@
                                   <div class="mb-3 mt-3 row">
                                     <form id="myForm" action="" method="POST"
                                       onchange="SetData('dryfruit_seva_amount','Dry Fruits')">
+                                      {% csrf_token %}
                                       <div class="tab-content" id="pills-tabContent">
                                         <div class="tab-pane fade show active" id="pills-dryfruites" role="tabpanel"
                                           aria-labelledby="pills-dryfruites-tab">


### PR DESCRIPTION
## Summary
- add `{% csrf_token %}` to wheat flour, edible oil, and dry fruit donation forms

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement python-dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a6ce5e0832da68516ddf8c01c4d