### PR TITLE
Add CSRF trusted origins for production

### DIFF
--- a/iskcongkp/settings/production.py
+++ b/iskcongkp/settings/production.py
@@ -30,6 +30,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 #DEBUG = True
 ALLOWED_HOSTS = ["iskcongorakhpur.com"]
 
+CSRF_TRUSTED_ORIGINS = ["https://iskcongorakhpur.com"]
 
 # Application definition
 


### PR DESCRIPTION
## Summary
- trust https://iskcongorakhpur.com for CSRF checks in production settings

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `python manage.py runserver` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68af1b8ca01c832db558363b79727408