### PR TITLE
Add pycryptodome and requests dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ packaging==25.0
 pillow==11.1.0
 psycopg2-binary==2.9.10
 sqlparse==0.5.3
+
+pycryptodome>=3.20
+requests>=2.32


### PR DESCRIPTION
## Summary
- add pycryptodome and requests dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pycryptodome>=3.20)*
- `pytest` *(fails: Requested setting DEBUG, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68af7060856c832da3eb6aac7d56cf5e