### PR TITLE
Add HDFC payment callback view

### DIFF
--- a/donation/views.py
+++ b/donation/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.shortcuts import render, redirect
 from .forms import DonationForm
 from payments.hdfc import encrypt
+from payments.hdfc import decrypt
 
 # Create your views here.
 
@@ -59,3 +60,14 @@ def tula_daan(request):
 
 def donate_brick(request):
     return render(request, 'donation/donate-brick.html')
+
+
+def callback(request):
+    enc_resp = request.POST.get("encResp")
+    if not enc_resp:
+        return render(request, "donation/failure.html")
+    response = dict(item.split("=") for item in decrypt(enc_resp).split("&"))
+    if response.get("order_status") == "Success":
+        # mark order paid here
+        return render(request, "donation/success.html", {"data": response})
+    return render(request, "donation/failure.html", {"data": response})


### PR DESCRIPTION
## Summary
- add HDFC callback handler that decrypts the response and renders success/failure pages

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement python-dotenv: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af763a6340832db2533ad0579fff37