### PR TITLE
Add donation payment templates

### DIFF
--- a/templates/donation/failure.html
+++ b/templates/donation/failure.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <h1>Payment failed.</h1>
+</body>
+</html>

--- a/templates/donation/pay.html
+++ b/templates/donation/pay.html
@@ -1,0 +1,5 @@
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Pay</button>
+</form>

--- a/templates/donation/redirect.html
+++ b/templates/donation/redirect.html
@@ -1,0 +1,5 @@
+<form id="pay" method="post" action="{{ payment_url }}">
+  <input type="hidden" name="encRequest" value="{{ enc_request }}">
+  <input type="hidden" name="access_code" value="{{ access_code }}">
+</form>
+<script>document.getElementById("pay").submit();</script>

--- a/templates/donation/success.html
+++ b/templates/donation/success.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <h1>Payment successful.</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple payment form template
- include auto-submitting redirect template
- add success and failure pages for payment flow

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement python-dotenv: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af7d933d30832d913813096a7b4f8c