### PR TITLE
Refactor HDFC config and remove unused constants

### DIFF
--- a/donation/views.py
+++ b/donation/views.py
@@ -13,7 +13,7 @@ def pay(request):
             order_id = form.cleaned_data["order_id"]
             amount = form.cleaned_data["amount"]
             params = {
-                "merchant_id": settings.HDFC_MERCHANT_ID,
+                "merchant_id": settings.HDFC_SMART["MERCHANT_ID"],
                 "order_id": order_id,
                 "currency": "INR",
                 "amount": f"{amount:.2f}",
@@ -25,8 +25,6 @@ def pay(request):
             enc_request = encrypt(query)
             context = {
                 "enc_request": enc_request,
-                "access_code": settings.HDFC_ACCESS_CODE,
-                "payment_url": settings.HDFC_PAYMENT_URL,
             }
             return render(request, "donation/redirect.html", context)
     else:

--- a/iskcongkp/settings/base.py
+++ b/iskcongkp/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 import os
 import os.path
+from django.core.exceptions import ImproperlyConfigured
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -24,6 +25,13 @@ HDFC_SMART = {
     "RESPONSE_KEY": os.environ.get("HDFC_RESPONSE_KEY"),
     "RETURN_URL": os.environ.get("HDFC_RETURN_URL"),
 }
+
+_required_hdfc_keys = ["BASE_URL", "API_KEY", "MERCHANT_ID", "CLIENT_ID", "RESPONSE_KEY", "RETURN_URL"]
+_missing_hdfc_keys = [k for k in _required_hdfc_keys if not HDFC_SMART.get(k)]
+if _missing_hdfc_keys:
+    raise ImproperlyConfigured(
+        "Missing HDFC_SMART settings: " + ", ".join(_missing_hdfc_keys)
+    )
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/iskcongkp/settings/production.py
+++ b/iskcongkp/settings/production.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 import os
 import os.path
+from django.core.exceptions import ImproperlyConfigured
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -25,6 +26,13 @@ HDFC_SMART = {
     "RESPONSE_KEY": os.environ.get("HDFC_RESPONSE_KEY"),
     "RETURN_URL": os.environ.get("HDFC_RETURN_URL"),
 }
+
+_required_hdfc_keys = ["BASE_URL", "API_KEY", "MERCHANT_ID", "CLIENT_ID", "RESPONSE_KEY", "RETURN_URL"]
+_missing_hdfc_keys = [k for k in _required_hdfc_keys if not HDFC_SMART.get(k)]
+if _missing_hdfc_keys:
+    raise ImproperlyConfigured(
+        "Missing HDFC_SMART settings: " + ", ".join(_missing_hdfc_keys)
+    )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(


### PR DESCRIPTION
## Summary
- remove legacy HDFC_ACCESS_CODE and HDFC_PAYMENT_URL usage
- validate required HDFC_SMART settings on startup

## Testing
- `python manage.py check` *(fails: No module named 'Crypto')*


------
https://chatgpt.com/codex/tasks/task_e_68af802c3210832db1eeb98ee4dcbe9d