### PR TITLE
Refactor donation payment flow

### DIFF
--- a/donation/urls.py
+++ b/donation/urls.py
@@ -12,7 +12,5 @@ urlpatterns = [
     path("janmashtami-seva", views.janmashtami_seva, name="janmashtami_seva"),
     path("tula-daan-utsav", views.tula_daan, name="tula_daan"),
     path("donate-a-brick", views.donate_brick, name="donate_brick"),
-    path("pay/", views.pay, name="pay"),
-    path("callback/", views.callback, name="callback"),
-    
+    path("pay/", views.start_donation_payment, name="pay"),
 ]


### PR DESCRIPTION
## Summary
- Replace donation `pay` view with `start_donation_payment` that forwards form info to payment module
- Drop obsolete encrypt/decrypt helpers and callback route
- Update donation URLs to use new wrapper view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68af82193570832dac1688d5805c0187