### PR TITLE
Add reusable donation form and start payment wrapper

### DIFF
--- a/donation/forms.py
+++ b/donation/forms.py
@@ -1,5 +1,11 @@
 from django import forms
 
+
 class DonationForm(forms.Form):
-    order_id = forms.CharField(max_length=64)
+    """Collect basic donor information for a donation payment."""
+
+    name = forms.CharField(max_length=100)
+    email = forms.EmailField()
+    phone = forms.CharField(max_length=20, required=False)
     amount = forms.DecimalField(decimal_places=2, max_digits=10)
+    category = forms.CharField(max_length=100, required=False)

--- a/donation/urls.py
+++ b/donation/urls.py
@@ -12,5 +12,5 @@ urlpatterns = [
     path("janmashtami-seva", views.janmashtami_seva, name="janmashtami_seva"),
     path("tula-daan-utsav", views.tula_daan, name="tula_daan"),
     path("donate-a-brick", views.donate_brick, name="donate_brick"),
-    path("pay/", views.start_donation_payment, name="pay"),
+    path("start-payment/", views.start_payment, name="start_payment"),
 ]

--- a/donation/views.py
+++ b/donation/views.py
@@ -1,32 +1,36 @@
 from django.shortcuts import render, redirect
 from django.urls import reverse
+from django.http import HttpResponseBadRequest
 from urllib.parse import urlencode
 
 from .forms import DonationForm
 
 
-def start_donation_payment(request):
-    if request.method == "POST":
-        form = DonationForm(request.POST)
-        if form.is_valid():
-            amount = form.cleaned_data.get("amount")
-            name = request.POST.get("name", "")
-            email = request.POST.get("email", "")
-            phone = request.POST.get("phone", "")
-            category = request.POST.get("category", "")
-            params = urlencode(
-                {
-                    "amount": amount,
-                    "name": name,
-                    "email": email,
-                    "phone": phone,
-                    "category": category,
-                }
-            )
-            return redirect(f"{reverse('payment:hdfc_start')}?{params}")
-    else:
-        form = DonationForm()
-    return render(request, "donation/pay.html", {"form": form})
+def start_payment(request):
+    """Wrapper view to redirect donation details to the payment app."""
+
+    if request.method != "POST":
+        return HttpResponseBadRequest("Invalid request")
+
+    form = DonationForm(request.POST)
+    if not form.is_valid():
+        return HttpResponseBadRequest("Invalid data")
+
+    amount = form.cleaned_data.get("amount")
+    name = form.cleaned_data.get("name", "")
+    email = form.cleaned_data.get("email", "")
+    phone = form.cleaned_data.get("phone", "")
+    category = form.cleaned_data.get("category", "")
+    params = urlencode(
+        {
+            "amount": amount,
+            "name": name,
+            "email": email,
+            "phone": phone,
+            "category": category,
+        }
+    )
+    return redirect(f"{reverse('payment:hdfc_start')}?{params}")
 
 
 def shastra_daan(request):

--- a/templates/donation/_donation_form.html
+++ b/templates/donation/_donation_form.html
@@ -1,0 +1,21 @@
+<form action="{% url 'donation:start_payment' %}" method="post" class="donation-form">
+  {% csrf_token %}
+  <input type="hidden" name="category" value="{{ category }}">
+  <div class="mb-3">
+    <label for="donation-name" class="form-label">Name</label>
+    <input type="text" class="form-control" id="donation-name" name="name" required>
+  </div>
+  <div class="mb-3">
+    <label for="donation-email" class="form-label">Email</label>
+    <input type="email" class="form-control" id="donation-email" name="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="donation-phone" class="form-label">Phone</label>
+    <input type="text" class="form-control" id="donation-phone" name="phone">
+  </div>
+  <div class="mb-3">
+    <label for="donation-amount" class="form-label">Donation Amount</label>
+    <input type="number" class="form-control" id="donation-amount" name="amount" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Donate Now</button>
+</form>

--- a/templates/donation/annadaan.html
+++ b/templates/donation/annadaan.html
@@ -274,10 +274,13 @@
                                                             <p>Prime Minister message on ISKCON "Food For Life
                                                                 Programme"</p>
                                                         </blockquote>
-                                                        <p><img src="{% static 'themes/images/pm_message.jpg' %}"
+                                                    <p><img src="{% static 'themes/images/pm_message.jpg' %}"
                                                                 alt="PM message" width="100%" height="100%" /></p>
                                                     </div>
 
+                                                    <div class="my-4">
+                                                      {% include 'donation/_donation_form.html' with category='Annadana Seva' %}
+                                                    </div>
 
                                                     <span class="a2a_kit a2a_kit_size_32 addtoany_list"
                                                         data-a2a-url="https://iskcongorakhpur.com/donation/annadana-seva"

--- a/templates/donation/donate-brick.html
+++ b/templates/donation/donate-brick.html
@@ -141,6 +141,9 @@
                                                         </ul>
                                                     </div>
 
+                                                    <div class="my-4">
+                                                      {% include 'donation/_donation_form.html' with category='Donate a Brick' %}
+                                                    </div>
 
                                                     <span class="a2a_kit a2a_kit_size_32 addtoany_list"
                                                         data-a2a-url="https://iskconbangalore.co.in/donation/donate-a-brick"

--- a/templates/donation/janmashtami.html
+++ b/templates/donation/janmashtami.html
@@ -263,19 +263,22 @@
                                                                     ISKCON <br />Account number: 50100662519656
                                                                     <br />IFSC: HDFC0004217 <br />Bank: HDFC BANK
                                                                     <br />BRANCH: Taramandal</p>
-                                                                <p>For more details contact <a
-                                                                        href="tel:+919170572937">9170572937</a>, <a
-                                                                        href="tel:+917880964086">7880964086</a></p>
-                                                            </div>
-                                                        </div>
+                                                        <p>For more details contact <a
+                                                                href="tel:+919170572937">9170572937</a>, <a
+                                                                href="tel:+917880964086">7880964086</a></p>
                                                     </div>
+                                                </div>
+                                            </div>
 
+                                            <div class="my-4">
+                                              {% include 'donation/_donation_form.html' with category='Janmashtami Seva' %}
+                                            </div>
 
-                                                    <span class="a2a_kit a2a_kit_size_32 addtoany_list"
-                                                        data-a2a-url="https://iskconbangalore.co.in/donation/janmashtami-seva"
-                                                        data-a2a-title="Janmashtami Seva"><a
-                                                            class="a2a_button_facebook"></a><a
-                                                            class="a2a_button_whatsapp"></a><a
+                                            <span class="a2a_kit a2a_kit_size_32 addtoany_list"
+                                                data-a2a-url="https://iskconbangalore.co.in/donation/janmashtami-seva"
+                                                data-a2a-title="Janmashtami Seva"><a
+                                                    class="a2a_button_facebook"></a><a
+                                                    class="a2a_button_whatsapp"></a><a
                                                             class="a2a_button_email"></a><a
                                                             class="a2a_dd addtoany_share"
                                                             href="https://www.addtoany.com/share#url=https%3A%2F%2Fiskconbangalore.co.in%2Fdonation%2Fjanmashtami-seva&amp;title=Janmashtami%20Seva"></a></span>

--- a/templates/donation/nitya-seva.html
+++ b/templates/donation/nitya-seva.html
@@ -192,18 +192,21 @@
                                                                     ISKCON <br />Account number: 50100662519656
                                                                     <br />IFSC: HDFC0004217 <br />Bank: HDFC BANK
                                                                     <br />BRANCH: Taramandal</p>
-                                                                <p>For more details contact <a
-                                                                        href="tel:+919170572937">9170572937</a>, <a
-                                                                        href="tel:+917880964086">7880964086</a></p>
-                                                            </div>
-                                                        </div>
+                                                        <p>For more details contact <a
+                                                                href="tel:+919170572937">9170572937</a>, <a
+                                                                href="tel:+917880964086">7880964086</a></p>
                                                     </div>
+                                                </div>
+                                            </div>
 
+                                            <div class="my-4">
+                                              {% include 'donation/_donation_form.html' with category='Nitya Seva' %}
+                                            </div>
 
-                                                    <span class="a2a_kit a2a_kit_size_32 addtoany_list"
-                                                        data-a2a-url="https://iskconbangalore.co.in/donation/nitya-seva"
-                                                        data-a2a-title="Nitya Seva"><a
-                                                            class="a2a_button_facebook"></a><a
+                                            <span class="a2a_kit a2a_kit_size_32 addtoany_list"
+                                                data-a2a-url="https://iskconbangalore.co.in/donation/nitya-seva"
+                                                data-a2a-title="Nitya Seva"><a
+                                                    class="a2a_button_facebook"></a><a
                                                             class="a2a_button_whatsapp"></a><a
                                                             class="a2a_button_email"></a><a
                                                             class="a2a_dd addtoany_share"

--- a/templates/donation/shastra-daan.html
+++ b/templates/donation/shastra-daan.html
@@ -240,6 +240,9 @@
                             </div>
                           </div>
 
+                          <div class="my-4">
+                            {% include 'donation/_donation_form.html' with category='Shastra Daan' %}
+                          </div>
 
                           <span class="a2a_kit a2a_kit_size_32 addtoany_list"
                             data-a2a-url="https://iskcongorakhpur.com/donation/shastra-daan"

--- a/templates/donation/temple-seva.html
+++ b/templates/donation/temple-seva.html
@@ -254,18 +254,21 @@
                                                                     <br />IFSC: HDFC0004217 <br />Bank: HDFC BANK
                                                                     <br />BRANCH: Taramandal
                                                                 </p>
-                                                                <p>For more details contact <a
-                                                                        href="tel:+919170572937">9170572937</a>, <a
-                                                                        href="tel:+917880964086">7880964086</a></p>
-                                                            </div>
-                                                        </div>
+                                                        <p>For more details contact <a
+                                                                href="tel:+919170572937">9170572937</a>, <a
+                                                                href="tel:+917880964086">7880964086</a></p>
                                                     </div>
+                                                </div>
+                                            </div>
 
+                                            <div class="my-4">
+                                              {% include 'donation/_donation_form.html' with category='Temple Seva' %}
+                                            </div>
 
-                                                    <span class="a2a_kit a2a_kit_size_32 addtoany_list"
-                                                        data-a2a-url="https://iskcongorakhpur.com/donation/temple-seva"
-                                                        data-a2a-title="Temple Sevas"><a
-                                                            class="a2a_button_facebook"></a><a
+                                            <span class="a2a_kit a2a_kit_size_32 addtoany_list"
+                                                data-a2a-url="https://iskcongorakhpur.com/donation/temple-seva"
+                                                data-a2a-title="Temple Sevas"><a
+                                                    class="a2a_button_facebook"></a><a
                                                             class="a2a_button_whatsapp"></a><a
                                                             class="a2a_button_email"></a><a
                                                             class="a2a_dd addtoany_share"

--- a/templates/donation/tula-daan.html
+++ b/templates/donation/tula-daan.html
@@ -1074,12 +1074,14 @@
                                         </div>
                                       </div>
                                     </form>
-                                  </div>
-                                </div>
                               </div>
                             </div>
                           </div>
-
+                        </div>
+                      </div>
+                      <div class="my-4">
+                        {% include 'donation/_donation_form.html' with category='Tula Daan Utsav' %}
+                      </div>
 
                           <span class="a2a_kit a2a_kit_size_32 addtoany_list"
                             data-a2a-url="https://iskcongorakhpur.com/donation/tula-daan-utsav"


### PR DESCRIPTION
## Summary
- add `start_payment` wrapper view and URL for donations
- collect donor name, email, phone, and amount via new `DonationForm`
- include reusable donation form across donation templates

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68af845915d8832da9b4a4cdb71280db