### PR TITLE
Add payment status templates and redirect

### DIFF
--- a/payment/views.py
+++ b/payment/views.py
@@ -101,5 +101,5 @@ def hdfc_return(request):
     except Order.DoesNotExist:
         return HttpResponseBadRequest("Unknown order_id")
 
-    return redirect(f"/thank-you?order_id={order_id}") if order.status == "paid" \
-           else redirect(f"/payment-error?order_id={order_id}")
+    template = "donation/success.html" if order.status == "paid" else "donation/failure.html"
+    return render(request, template, {"order": order})

--- a/templates/donation/failure.html
+++ b/templates/donation/failure.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+{% load static %}
+<html lang="en" dir="ltr">
+<head>
+    {% include 'head.html' %}
+    <title>Payment Failed</title>
+</head>
+<body class="layout-no-sidebars page-node-148 path-node node--type-page">
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
+    <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+        <div id="page-wrapper">
+            <div id="page">
+                {% include 'navbar.html' %}
+                <div id="main-wrapper" class="layout-main-wrapper clearfix">
+                    <div id="main" class="container">
+                        <div class="row row-offcanvas row-offcanvas-left clearfix">
+                            <main class="main-content col" id="content" role="main">
+                                <section class="section">
+                                    <a id="main-content" tabindex="-1"></a>
+                                    <h1 class="title">Payment Failed</h1>
+                                    <p>Your transaction could not be completed.</p>
+                                    <p><strong>Order ID:</strong> {{ order.order_id }}</p>
+                                    <p><strong>Amount:</strong> {{ order.amount }} {{ order.currency }}</p>
+                                    {% if order.gateway_txn_id %}
+                                    <p><strong>Transaction ID:</strong> {{ order.gateway_txn_id }}</p>
+                                    {% endif %}
+                                </section>
+                            </main>
+                        </div>
+                    </div>
+                </div>
+                {% include 'footer.html' %}
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/donation/redirect.html
+++ b/templates/donation/redirect.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Redirecting to Payment...</title>
+    <script>
+        window.onload = function () {
+            var link = "{{ payment_link }}";
+            if (link) {
+                window.location.href = link;
+            }
+        };
+    </script>
+</head>
+<body>
+    <p>Redirecting to payment gateway&hellip;</p>
+    <noscript>
+        <p><a href="{{ payment_link }}">Click here to continue</a></p>
+    </noscript>
+</body>
+</html>

--- a/templates/donation/success.html
+++ b/templates/donation/success.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+{% load static %}
+<html lang="en" dir="ltr">
+<head>
+    {% include 'head.html' %}
+    <title>Payment Successful</title>
+</head>
+<body class="layout-no-sidebars page-node-148 path-node node--type-page">
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
+    <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+        <div id="page-wrapper">
+            <div id="page">
+                {% include 'navbar.html' %}
+                <div id="main-wrapper" class="layout-main-wrapper clearfix">
+                    <div id="main" class="container">
+                        <div class="row row-offcanvas row-offcanvas-left clearfix">
+                            <main class="main-content col" id="content" role="main">
+                                <section class="section">
+                                    <a id="main-content" tabindex="-1"></a>
+                                    <h1 class="title">Thank You!</h1>
+                                    <p>Your transaction was successful.</p>
+                                    <p><strong>Order ID:</strong> {{ order.order_id }}</p>
+                                    <p><strong>Amount:</strong> {{ order.amount }} {{ order.currency }}</p>
+                                    <p><strong>Transaction ID:</strong> {{ order.gateway_txn_id }}</p>
+                                </section>
+                            </main>
+                        </div>
+                    </div>
+                </div>
+                {% include 'footer.html' %}
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add redirect, success, and failure templates for donations
- render success or failure template from HDFC return view based on order status

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68af864973f0832d86866f3fea6526e0