### PR TITLE
Capture and log HDFC payment errors

### DIFF
--- a/payment/admin.py
+++ b/payment/admin.py
@@ -1,3 +1,11 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Order
+
+
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    list_display = ("order_id", "status", "amount", "gateway_order_id", "created_at")
+    search_fields = ("order_id", "gateway_order_id", "gateway_txn_id")
+    readonly_fields = ("raw_req", "raw_resp", "webhook")
+    ordering = ("-created_at",)

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -1,8 +1,10 @@
 import base64
 
 from django.test import TestCase, override_settings
+from unittest.mock import patch
 
 from . import utils
+from .models import Order
 
 
 class BasicAuthHeaderTests(TestCase):
@@ -39,4 +41,29 @@ class BasicAuthHeaderTests(TestCase):
 
         expected = "Basic " + base64.b64encode(b"api:").decode()
         self.assertEqual(utils.basic_auth_header(), expected)
+ 
 
+class StartPaymentErrorTests(TestCase):
+    @override_settings(
+        HDFC_SMART={
+            "BASE_URL": "https://example.com",
+            "API_KEY": "api",
+            "MERCHANT_ID": "merchant",
+            "CLIENT_ID": "client",
+            "RESPONSE_KEY": "resp",
+            "RETURN_URL": "https://example.com/return",
+        }
+    )
+    def test_non_200_response_saved_to_order(self):
+        class FakeResponse:
+            status_code = 500
+            text = "server error"
+
+        with patch("payment.views.requests.post", return_value=FakeResponse()):
+            with self.assertLogs("payment.views", level="ERROR") as cm:
+                resp = self.client.get("/payment/hdfc/start/?amount=100")
+
+        self.assertEqual(resp.status_code, 400)
+        order = Order.objects.get()
+        self.assertEqual(order.raw_resp, {"status_code": 500, "text": "server error"})
+        self.assertIn(order.order_id, cm.output[0])


### PR DESCRIPTION
## Summary
- Persist HDFC status and response body in `Order.raw_resp` when session creation fails
- Register the Order model in admin with useful search and read-only fields
- Test that non-200 HDFC responses are logged and stored for lookup by order ID

## Testing
- `HDFC_BASE_URL=https://example.com HDFC_API_KEY=api HDFC_MERCHANT_ID=merchant HDFC_CLIENT_ID=client HDFC_RESPONSE_KEY=resp HDFC_RETURN_URL=https://example.com/return python manage.py test --settings=iskcongkp.settings.test`

------
https://chatgpt.com/codex/tasks/task_e_68afd1a4e680832db7cb289ec1e634da