### PR TITLE
Update HDFC settings with key path and UUID fields

### DIFF
--- a/iskcongkp/settings/base.py
+++ b/iskcongkp/settings/base.py
@@ -19,14 +19,25 @@ load_dotenv()
 
 HDFC_SMART = {
     "BASE_URL": os.environ.get("HDFC_BASE_URL", "https://smartgatewayuat.hdfcbank.com"),
-    "API_KEY": os.environ.get("HDFC_API_KEY"),
+    "PRIVATE_KEY_PATH": os.environ.get("HDFC_PRIVATE_KEY_PATH"),
+    "PUBLIC_KEY_PATH": os.environ.get("HDFC_PUBLIC_KEY_PATH"),
+    "KEY_UUID": os.environ.get("HDFC_KEY_UUID"),
+    "PAYMENT_PAGE_CLIENT_ID": os.environ.get("HDFC_PAYMENT_PAGE_CLIENT_ID"),
     "MERCHANT_ID": os.environ.get("HDFC_MERCHANT_ID"),
-    "CLIENT_ID": os.environ.get("HDFC_CLIENT_ID"),  # 'hdfcmaster' on UAT
     "RESPONSE_KEY": os.environ.get("HDFC_RESPONSE_KEY"),
     "RETURN_URL": os.environ.get("HDFC_RETURN_URL"),
 }
 
-_required_hdfc_keys = ["BASE_URL", "API_KEY", "MERCHANT_ID", "CLIENT_ID", "RESPONSE_KEY", "RETURN_URL"]
+_required_hdfc_keys = [
+    "BASE_URL",
+    "MERCHANT_ID",
+    "PRIVATE_KEY_PATH",
+    "PUBLIC_KEY_PATH",
+    "KEY_UUID",
+    "PAYMENT_PAGE_CLIENT_ID",
+    "RESPONSE_KEY",
+    "RETURN_URL",
+]
 _missing_hdfc_keys = [k for k in _required_hdfc_keys if not HDFC_SMART.get(k)]
 if _missing_hdfc_keys:
     raise ImproperlyConfigured(

--- a/iskcongkp/settings/production.py
+++ b/iskcongkp/settings/production.py
@@ -20,14 +20,25 @@ load_dotenv()
 
 HDFC_SMART = {
     "BASE_URL": os.environ.get("HDFC_BASE_URL", "https://smartgatewayuat.hdfcbank.com"),
-    "API_KEY": os.environ.get("HDFC_API_KEY"),
+    "PRIVATE_KEY_PATH": os.environ.get("HDFC_PRIVATE_KEY_PATH"),
+    "PUBLIC_KEY_PATH": os.environ.get("HDFC_PUBLIC_KEY_PATH"),
+    "KEY_UUID": os.environ.get("HDFC_KEY_UUID"),
+    "PAYMENT_PAGE_CLIENT_ID": os.environ.get("HDFC_PAYMENT_PAGE_CLIENT_ID"),
     "MERCHANT_ID": os.environ.get("HDFC_MERCHANT_ID"),
-    "CLIENT_ID": os.environ.get("HDFC_CLIENT_ID"),  # 'hdfcmaster' on UAT
     "RESPONSE_KEY": os.environ.get("HDFC_RESPONSE_KEY"),
     "RETURN_URL": os.environ.get("HDFC_RETURN_URL"),
 }
 
-_required_hdfc_keys = ["BASE_URL", "API_KEY", "MERCHANT_ID", "CLIENT_ID", "RESPONSE_KEY", "RETURN_URL"]
+_required_hdfc_keys = [
+    "BASE_URL",
+    "MERCHANT_ID",
+    "PRIVATE_KEY_PATH",
+    "PUBLIC_KEY_PATH",
+    "KEY_UUID",
+    "PAYMENT_PAGE_CLIENT_ID",
+    "RESPONSE_KEY",
+    "RETURN_URL",
+]
 _missing_hdfc_keys = [k for k in _required_hdfc_keys if not HDFC_SMART.get(k)]
 if _missing_hdfc_keys:
     raise ImproperlyConfigured(


### PR DESCRIPTION
## Summary
- replace HDFC API and client identifiers with key path and UUID fields
- update required HDFC key list accordingly

## Testing
- `HDFC_PRIVATE_KEY_PATH=priv HDFC_PUBLIC_KEY_PATH=pub HDFC_KEY_UUID=uuid HDFC_PAYMENT_PAGE_CLIENT_ID=ppcid HDFC_MERCHANT_ID=mid HDFC_RESPONSE_KEY=rkey HDFC_RETURN_URL=rurl python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68afd5974dec832daac6d471cb72417b