### PR TITLE
Use JWT auth header and rename client id setting

### DIFF
--- a/payment/tests.py
+++ b/payment/tests.py
@@ -37,7 +37,7 @@ class StartPaymentErrorTests(TestCase):
         HDFC_SMART={
             "BASE_URL": "https://example.com",
             "MERCHANT_ID": "merchant",
-            "CLIENT_ID": "client",
+            "PAYMENT_PAGE_CLIENT_ID": "client",
             "RESPONSE_KEY": "resp",
             "RETURN_URL": "https://example.com/return",
         }

--- a/payment/views.py
+++ b/payment/views.py
@@ -36,7 +36,7 @@ def start_payment(request):
     # Confirm exact keys from your sample project page.
     payload = {
         "merchant_id": settings.HDFC_SMART["MERCHANT_ID"],
-        "client_id": settings.HDFC_SMART["CLIENT_ID"],  # 'hdfcmaster' in UAT
+        "client_id": settings.HDFC_SMART["PAYMENT_PAGE_CLIENT_ID"],  # 'hdfcmaster' in UAT
         "order_id": order.order_id,
         "amount": str(order.amount),
         "currency": "INR",


### PR DESCRIPTION
## Summary
- reference new `PAYMENT_PAGE_CLIENT_ID` value when generating HDFC payment session payload
- adjust tests for renamed `PAYMENT_PAGE_CLIENT_ID` configuration

## Testing
- `PYTHONPATH=/tmp:$PYTHONPATH ENVIRONMENT_NAME=test HDFC_PRIVATE_KEY_PATH=/tmp/dummy_private.key HDFC_PUBLIC_KEY_PATH=/tmp/dummy_public.key HDFC_KEY_UUID=uuid HDFC_PAYMENT_PAGE_CLIENT_ID=client HDFC_MERCHANT_ID=merchant HDFC_RESPONSE_KEY=resp HDFC_RETURN_URL=https://example.com/return python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68afdb875e14832d8db7eb14ca21a053