### PR TITLE
Install PyJWT with crypto extras for RS256

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ psycopg2-binary==2.9.10
 sqlparse==0.5.3
 
 requests>=2.32
-PyJWT>=2.9
+PyJWT[crypto]>=2.9


### PR DESCRIPTION
## Summary
- enable RS256 JWT support by installing `PyJWT[crypto]`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyJWT>=2.9)*
- `python manage.py test` *(fails: Missing HDFC_SMART settings)*

------
https://chatgpt.com/codex/tasks/task_e_68afefc48598832d8dfbe49de17eddf3