### PR TITLE
Validate HDFC response key before computing HMAC

### DIFF
--- a/payment/tests.py
+++ b/payment/tests.py
@@ -4,9 +4,17 @@ import tempfile
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 import jwt
+from django.core.exceptions import ImproperlyConfigured
 
 from . import utils
 from .models import Order
+
+
+class VerifyHmacTests(TestCase):
+    def test_missing_response_key_raises(self):
+        with override_settings(HDFC_SMART={}):
+            with self.assertRaises(ImproperlyConfigured):
+                utils.verify_hmac({}, "sig", [])
 
 
 class JwtAuthHeaderTests(TestCase):
@@ -130,7 +138,7 @@ class HdfcReturnJwtVerificationTests(TestCase):
             "jwt": "tok",
         }
         with patch("payment.views.verify_hmac", return_value=True), patch(
-            "payment.views.verify_response_jwt", return_value={}
+            "payment.views.verify_response_jwt", return_value={"ok": True}
         ):
             self.client.post("/payment/hdfc/return/", data)
         self.order.refresh_from_db()


### PR DESCRIPTION
## Summary
- ensure `verify_hmac` raises `ImproperlyConfigured` when `HDFC_SMART['RESPONSE_KEY']` is missing
- add unit test covering missing response key and adjust JWT verification test

## Testing
- `ENVIRONMENT_NAME=test HDFC_BASE_URL=https://example.com HDFC_PRIVATE_KEY_PATH=/tmp/priv HDFC_PUBLIC_KEY_PATH=/tmp/pub HDFC_KEY_UUID=uuid HDFC_PAYMENT_PAGE_CLIENT_ID=client HDFC_MERCHANT_ID=m HDFC_RESPONSE_KEY=resp HDFC_RETURN_URL=https://example.com python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b04ed4ed6c832d9fc1e70a1a833ea5