### PR TITLE
Add HDFC SmartGateway basic auth helper

### DIFF
--- a/iskcongkp/settings/base.py
+++ b/iskcongkp/settings/base.py
@@ -26,6 +26,7 @@ HDFC_SMART = {
     "MERCHANT_ID": os.environ.get("HDFC_MERCHANT_ID"),
     "RESPONSE_KEY": os.environ.get("HDFC_RESPONSE_KEY"),
     "RETURN_URL": os.environ.get("HDFC_RETURN_URL"),
+    "API_KEY": os.environ.get("HDFC_API_KEY"),
 }
 
 _required_hdfc_keys = [

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase, override_settings
 from unittest.mock import patch
 import tempfile
+import base64
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 import jwt
@@ -15,6 +16,19 @@ class VerifyHmacTests(TestCase):
         with override_settings(HDFC_SMART={}):
             with self.assertRaises(ImproperlyConfigured):
                 utils.verify_hmac({}, "sig", [])
+
+
+class BasicAuthHeaderTests(TestCase):
+    def test_header_encodes_api_key(self):
+        with override_settings(HDFC_SMART={"API_KEY": "secret"}):
+            header = utils.basic_auth_header()
+        expected = base64.b64encode(b"secret").decode()
+        self.assertEqual(header, f"Basic {expected}")
+
+    def test_missing_api_key_raises(self):
+        with override_settings(HDFC_SMART={}):
+            with self.assertRaises(ImproperlyConfigured):
+                utils.basic_auth_header()
 
 
 class JwtAuthHeaderTests(TestCase):

--- a/payment/utils.py
+++ b/payment/utils.py
@@ -1,5 +1,6 @@
 """Utility helpers for the payment app."""
 
+import base64
 import hmac, hashlib, jwt, logging
 from datetime import datetime, timedelta, timezone
 from django.conf import settings
@@ -14,6 +15,27 @@ _PRIVATE_KEY = None
 _PRIVATE_KEY_PATH = None
 _PUBLIC_KEY = None
 _PUBLIC_KEY_PATH = None
+
+
+def basic_auth_header() -> str:
+    """Return the Basic Authorization header for HDFC SmartGateway.
+
+    The SmartGateway's REST APIs expect the merchant's API key to be
+    provided using HTTP Basic authentication.  We read the API key from
+    ``settings.HDFC_SMART["API_KEY"]`` and base64 encode it to build the
+    header value.  If the API key is missing the function raises
+    :class:`ImproperlyConfigured` and logs an error.
+    """
+
+    api_key = settings.HDFC_SMART.get("API_KEY")
+    if not api_key:
+        logger.error("HDFC SmartGateway API_KEY missing in settings")
+        raise ImproperlyConfigured(
+            "HDFC_SMART['API_KEY'] setting is required for basic auth"
+        )
+
+    encoded = base64.b64encode(api_key.encode()).decode()
+    return "Basic " + encoded
 
 
 def jwt_auth_header() -> str:


### PR DESCRIPTION
## Summary
- Add `basic_auth_header` utility for HDFC SmartGateway that returns a Basic auth header from the configured API key
- Load `HDFC_API_KEY` into settings under `HDFC_SMART['API_KEY']`
- Test basic auth header behavior and missing-key handling

## Testing
- `HDFC_BASE_URL=https://example.com HDFC_PRIVATE_KEY_PATH=/tmp/a HDFC_PUBLIC_KEY_PATH=/tmp/b HDFC_KEY_UUID=uuid HDFC_PAYMENT_PAGE_CLIENT_ID=client HDFC_MERCHANT_ID=merchant HDFC_RESPONSE_KEY=resp HDFC_RETURN_URL=https://example.com/return HDFC_API_KEY=api DJANGO_SETTINGS_MODULE=iskcongkp.settings.test python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b05aa0c114832d9c6a2433dab9924c