### PR TITLE
Use basic auth and add HDFC headers

### DIFF
--- a/iskcongkp/settings/base.py
+++ b/iskcongkp/settings/base.py
@@ -27,6 +27,8 @@ HDFC_SMART = {
     "RESPONSE_KEY": os.environ.get("HDFC_RESPONSE_KEY"),
     "RETURN_URL": os.environ.get("HDFC_RETURN_URL"),
     "API_KEY": os.environ.get("HDFC_API_KEY"),
+    "CUSTOMER_ID": os.environ.get("HDFC_CUSTOMER_ID"),
+    "RESELLER_ID": os.environ.get("HDFC_RESELLER_ID"),
 }
 
 _required_hdfc_keys = [

--- a/iskcongkp/settings/production.py
+++ b/iskcongkp/settings/production.py
@@ -27,6 +27,9 @@ HDFC_SMART = {
     "MERCHANT_ID": os.environ.get("HDFC_MERCHANT_ID"),
     "RESPONSE_KEY": os.environ.get("HDFC_RESPONSE_KEY"),
     "RETURN_URL": os.environ.get("HDFC_RETURN_URL"),
+    "API_KEY": os.environ.get("HDFC_API_KEY"),
+    "CUSTOMER_ID": os.environ.get("HDFC_CUSTOMER_ID"),
+    "RESELLER_ID": os.environ.get("HDFC_RESELLER_ID"),
 }
 
 _required_hdfc_keys = [


### PR DESCRIPTION
## Summary
- use basic auth and add HDFC-specific headers for session creation
- align HDFC start_payment payload and support redirectUrl
- extend test settings with customer and reseller IDs

## Testing
- `DJANGO_SETTINGS_MODULE=iskcongkp.settings.test python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b05c39e2e0832d80bf5276fcc930a8