### PR TITLE
Validate HDFC configuration on startup

### DIFF
--- a/iskcongkp/settings/base.py
+++ b/iskcongkp/settings/base.py
@@ -40,6 +40,9 @@ _required_hdfc_keys = [
     "PAYMENT_PAGE_CLIENT_ID",
     "RESPONSE_KEY",
     "RETURN_URL",
+    "API_KEY",
+    "CUSTOMER_ID",
+    "RESELLER_ID",
 ]
 _missing_hdfc_keys = [k for k in _required_hdfc_keys if not HDFC_SMART.get(k)]
 if _missing_hdfc_keys:

--- a/iskcongkp/settings/production.py
+++ b/iskcongkp/settings/production.py
@@ -41,6 +41,9 @@ _required_hdfc_keys = [
     "PAYMENT_PAGE_CLIENT_ID",
     "RESPONSE_KEY",
     "RETURN_URL",
+    "API_KEY",
+    "CUSTOMER_ID",
+    "RESELLER_ID",
 ]
 _missing_hdfc_keys = [k for k in _required_hdfc_keys if not HDFC_SMART.get(k)]
 if _missing_hdfc_keys:


### PR DESCRIPTION
## Summary
- Require HDFC_API_KEY, HDFC_CUSTOMER_ID, and HDFC_RESELLER_ID in settings
- Fail fast with ImproperlyConfigured if HDFC credentials are missing

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b05e0a8840832d86109b4ab5e6c657