### PR TITLE
Add authentication pages with navbar login option

### DIFF
--- a/iskcongkp/urls.py
+++ b/iskcongkp/urls.py
@@ -22,7 +22,7 @@ from django.conf.urls.static import static
 from django.views.static import serve
 
 
-from .views import  contact_view, privacy_view , terms_view, maintenance_view
+from .views import  contact_view, privacy_view , terms_view, maintenance_view, signup_view, signin_view, logout_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -35,6 +35,9 @@ urlpatterns = [
     path("terms", terms_view, name="terms"),
     path("privacy-policy", privacy_view, name="privacy-policy"),
     path("maintenance/", maintenance_view, name="maintenance"),
+    path("signup/", signup_view, name="signup"),
+    path("login/", signin_view, name="login"),
+    path("logout/", logout_view, name="logout"),
     url(r'^assets/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT}),
     url(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT})
 

--- a/iskcongkp/views.py
+++ b/iskcongkp/views.py
@@ -1,4 +1,6 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.contrib.auth import login, logout
+from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 
 def contact_view(request):
     return render(request, 'contact.html')
@@ -16,3 +18,31 @@ def error_404_view(request, exception):
     # we add the path to the 404.html file
     # here. The name of our HTML file is 404.html
     return render(request, '404.html', status=404)
+
+
+def signup_view(request):
+    if request.method == "POST":
+        form = UserCreationForm(request.POST)
+        if form.is_valid():
+            user = form.save()
+            login(request, user)
+            return redirect("homepage:homepage")
+    else:
+        form = UserCreationForm()
+    return render(request, "signup.html", {"form": form})
+
+
+def signin_view(request):
+    if request.method == "POST":
+        form = AuthenticationForm(request, data=request.POST)
+        if form.is_valid():
+            login(request, form.get_user())
+            return redirect("homepage:homepage")
+    else:
+        form = AuthenticationForm()
+    return render(request, "signin.html", {"form": form})
+
+
+def logout_view(request):
+    logout(request)
+    return redirect("homepage:homepage")

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -152,6 +152,21 @@
                                         <li class="nav-item px-md-3 px-lg-3 px-xl-3 px-xxl-3">
                                             <a href="/contact" class="nav-link nav-link--contact-us" data-drupal-link-system-path="node/34">Contact Us</a>
                                         </li>
+                                        {% if user.is_authenticated %}
+                                        <li class="nav-item px-md-3 px-lg-3 px-xl-3 px-xxl-3">
+                                            <a href="{% url 'logout' %}" class="nav-link">
+                                                <i class="fas fa-user-circle"></i>
+                                                <span class="d-inline d-md-none ms-1">Logout</span>
+                                            </a>
+                                        </li>
+                                        {% else %}
+                                        <li class="nav-item px-md-3 px-lg-3 px-xl-3 px-xxl-3">
+                                            <a href="{% url 'login' %}" class="nav-link">
+                                                <i class="fas fa-user-circle"></i>
+                                                <span class="d-inline d-md-none ms-1">Login</span>
+                                            </a>
+                                        </li>
+                                        {% endif %}
                                     </ul>
                                 </nav>
                             </div>

--- a/templates/signin.html
+++ b/templates/signin.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+{% load static %}
+<html lang="en" dir="ltr" prefix="og: https://ogp.me/ns#">
+<head>
+    {% include 'head.html' %}
+    <title>Sign In | ISKCON Gorakhpur</title>
+</head>
+<body class="layout-no-sidebars path-contact-usk node--type-page">
+    <a href="#main-content" class="visually-hidden-focusable">
+        Skip to main content
+    </a>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5RKQZD47" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+        <div id="page-wrapper">
+            <div id="page">
+                {% include 'navbar.html' %}
+                <div class="highlighted">
+                    <aside class="container section clearfix" role="complementary">
+                        <div data-drupal-messages-fallback class="hidden"></div>
+                    </aside>
+                </div>
+                <div id="main-wrapper" class="layout-main-wrapper clearfix">
+                    <div id="main" class="container">
+                        <div class="row row-offcanvas row-offcanvas-left clearfix">
+                            <main class="main-content col" id="content" role="main">
+                                <section class="section">
+                                    <a href="#main-content" id="main-content" tabindex="-1"></a>
+                                    <div id="block-akara-page-title" class="block block-core block-page-title-block">
+                                        <div class="content">
+                                            <h1 class="title"><span class="field field--name-title field--type-string field--label-hidden">Sign In</span></h1>
+                                        </div>
+                                    </div>
+                                    <div id="block-akara-content" class="block block-system block-system-main-block">
+                                        <div class="content">
+                                            <article role="article" class="node node--type-page node--view-mode-full clearfix">
+                                                <div class="node__content clearfix">
+                                                    <div class="clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item">
+                                                        <div class="col-xs-12 col-sm-12 col-md-12" style="display:flex;flex-wrap:wrap;text-align:center;">
+                                                            <div class="col-xs-12 col-sm-12 col-md-5" style="margin:0 auto;">
+                                                                <form method="post">
+                                                                    {% csrf_token %}
+                                                                    {{ form.as_p }}
+                                                                    <button type="submit" class="btn btn-primary">Sign In</button>
+                                                                </form>
+                                                                <p class="mt-3">Don't have an account? <a href="{% url 'signup' %}">Sign up</a>.</p>
+                                                            </div>
+                                                            <div class="col-xs-12 col-sm-12 col-md-5">
+                                                                <div class="align-right">
+                                                                    <div class="field field--name-field-media-image field--type-image field--label-visually_hidden">
+                                                                        <div class="field__item">
+                                                                            <picture>
+                                                                                <img src="{% static 'sites/krishna_help.png' %}" alt="Krishna Helping Devotees" />
+                                                                            </picture>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </article>
+                                        </div>
+                                    </div>
+                                </section>
+                            </main>
+                        </div>
+                    </div>
+                </div>
+                {% include 'footer.html' %}
+            </div>
+        </div>
+    </div>
+    {% include 'body_script.html' %}
+</body>
+</html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+{% load static %}
+<html lang="en" dir="ltr" prefix="og: https://ogp.me/ns#">
+<head>
+    {% include 'head.html' %}
+    <title>Sign Up | ISKCON Gorakhpur</title>
+</head>
+<body class="layout-no-sidebars path-contact-usk node--type-page">
+    <a href="#main-content" class="visually-hidden-focusable">
+        Skip to main content
+    </a>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5RKQZD47" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+        <div id="page-wrapper">
+            <div id="page">
+                {% include 'navbar.html' %}
+                <div class="highlighted">
+                    <aside class="container section clearfix" role="complementary">
+                        <div data-drupal-messages-fallback class="hidden"></div>
+                    </aside>
+                </div>
+                <div id="main-wrapper" class="layout-main-wrapper clearfix">
+                    <div id="main" class="container">
+                        <div class="row row-offcanvas row-offcanvas-left clearfix">
+                            <main class="main-content col" id="content" role="main">
+                                <section class="section">
+                                    <a href="#main-content" id="main-content" tabindex="-1"></a>
+                                    <div id="block-akara-page-title" class="block block-core block-page-title-block">
+                                        <div class="content">
+                                            <h1 class="title"><span class="field field--name-title field--type-string field--label-hidden">Sign Up</span></h1>
+                                        </div>
+                                    </div>
+                                    <div id="block-akara-content" class="block block-system block-system-main-block">
+                                        <div class="content">
+                                            <article role="article" class="node node--type-page node--view-mode-full clearfix">
+                                                <div class="node__content clearfix">
+                                                    <div class="clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item">
+                                                        <div class="col-xs-12 col-sm-12 col-md-12" style="display:flex;flex-wrap:wrap;text-align:center;">
+                                                            <div class="col-xs-12 col-sm-12 col-md-5" style="margin:0 auto;">
+                                                                <form method="post">
+                                                                    {% csrf_token %}
+                                                                    {{ form.as_p }}
+                                                                    <button type="submit" class="btn btn-primary">Sign Up</button>
+                                                                </form>
+                                                                <p class="mt-3">Already have an account? <a href="{% url 'login' %}">Sign in</a>.</p>
+                                                            </div>
+                                                            <div class="col-xs-12 col-sm-12 col-md-5">
+                                                                <div class="align-right">
+                                                                    <div class="field field--name-field-media-image field--type-image field--label-visually_hidden">
+                                                                        <div class="field__item">
+                                                                            <picture>
+                                                                                <img src="{% static 'sites/krishna_help.png' %}" alt="Krishna Helping Devotees" />
+                                                                            </picture>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </article>
+                                        </div>
+                                    </div>
+                                </section>
+                            </main>
+                        </div>
+                    </div>
+                </div>
+                {% include 'footer.html' %}
+            </div>
+        </div>
+    </div>
+    {% include 'body_script.html' %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sign-in and sign-up pages styled after 404 template
- wire up auth views and urls
- show login/logout profile icon in navbar for web and mobile

## Testing
- `python manage.py check` *(fails: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b09f4ff3dc832d994fc381c676b44a