### PR TITLE
Add SignUpForm with email/mobile and use in signup view

### DIFF
--- a/iskcongkp/forms.py
+++ b/iskcongkp/forms.py
@@ -1,0 +1,29 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+
+
+class SignUpForm(UserCreationForm):
+    """Custom user creation form with additional fields."""
+
+    email = forms.EmailField(required=True)
+    mobile = forms.CharField(required=True, max_length=15)
+
+    class Meta:
+        model = User
+        fields = ("username", "email", "mobile", "password1", "password2")
+        widgets = {
+            "username": forms.TextInput(attrs={"class": "form-control"}),
+            "email": forms.EmailInput(attrs={"class": "form-control"}),
+            "mobile": forms.TextInput(attrs={"class": "form-control"}),
+            "password1": forms.PasswordInput(attrs={"class": "form-control"}),
+            "password2": forms.PasswordInput(attrs={"class": "form-control"}),
+        }
+
+    def clean_username(self):
+        username = self.cleaned_data.get("username")
+        if User.objects.filter(username=username).exists():
+            raise ValidationError("A user with that username already exists.")
+        return username
+

--- a/iskcongkp/views.py
+++ b/iskcongkp/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth import login, logout
-from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
+from django.contrib.auth.forms import AuthenticationForm
+
+from .forms import SignUpForm
 
 def contact_view(request):
     return render(request, 'contact.html')
@@ -22,13 +24,13 @@ def error_404_view(request, exception):
 
 def signup_view(request):
     if request.method == "POST":
-        form = UserCreationForm(request.POST)
+        form = SignUpForm(request.POST)
         if form.is_valid():
             user = form.save()
             login(request, user)
             return redirect("homepage:homepage")
     else:
-        form = UserCreationForm()
+        form = SignUpForm()
     return render(request, "signup.html", {"form": form})
 
 


### PR DESCRIPTION
## Summary
- create custom SignUpForm with email and mobile fields and duplicate username validation
- update signup view to use SignUpForm

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68b0a510d61c832db164412d17bfed71