### PR TITLE
Add styled SignInForm and update signin view

### DIFF
--- a/iskcongkp/forms.py
+++ b/iskcongkp/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 
@@ -26,4 +26,15 @@ class SignUpForm(UserCreationForm):
         if User.objects.filter(username=username).exists():
             raise ValidationError("A user with that username already exists.")
         return username
+
+
+class SignInForm(AuthenticationForm):
+    """Authentication form with Bootstrap styling."""
+
+    username = forms.CharField(
+        widget=forms.TextInput(attrs={"class": "form-control", "required": True})
+    )
+    password = forms.CharField(
+        widget=forms.PasswordInput(attrs={"class": "form-control", "required": True})
+    )
 

--- a/iskcongkp/views.py
+++ b/iskcongkp/views.py
@@ -1,8 +1,7 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth import login, logout
-from django.contrib.auth.forms import AuthenticationForm
 
-from .forms import SignUpForm
+from .forms import SignInForm, SignUpForm
 
 def contact_view(request):
     return render(request, 'contact.html')
@@ -36,12 +35,12 @@ def signup_view(request):
 
 def signin_view(request):
     if request.method == "POST":
-        form = AuthenticationForm(request, data=request.POST)
+        form = SignInForm(request, data=request.POST)
         if form.is_valid():
             login(request, form.get_user())
             return redirect("homepage:homepage")
     else:
-        form = AuthenticationForm()
+        form = SignInForm()
     return render(request, "signin.html", {"form": form})
 
 


### PR DESCRIPTION
## Summary
- create `SignInForm` with Bootstrap-styled username and password widgets
- use `SignInForm` in `signin_view` instead of `AuthenticationForm`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b1353710832d8eae1a541bd99a5e