### PR TITLE
Validate HDFC credentials and document env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,22 @@ This repository contains the source code of a Django based website for ISKCON Go
 
 ## Environment variables
 
-The project expects two environment variables which can be placed in a `.env` file in the project root:
+The project expects the following environment variables which can be placed in a `.env` file in the project root:
 
 - `ENVIRONMENT_NAME` – selects the settings module. Set to `production` to use `iskcongkp.settings.production`, otherwise `iskcongkp.settings.base` is used.
 - `PASSWORD` – database password for the production settings file.
+- `HDFC_MERCHANT_ID` – merchant identifier for HDFC SmartGateway.
+- `HDFC_API_KEY` – API key for HDFC SmartGateway.
+
+Ensure `HDFC_MERCHANT_ID` and `HDFC_API_KEY` are configured in every environment where payments are processed.
 
 Example `.env`:
 
 ```ini
 ENVIRONMENT_NAME=production
 PASSWORD=your_db_password
+HDFC_MERCHANT_ID=your_merchant_id
+HDFC_API_KEY=your_api_key
 ```
 
 ## Running the site

--- a/iskcongkp/settings/base.py
+++ b/iskcongkp/settings/base.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 import os
 import os.path
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 # Load environment variables
 load_dotenv()
@@ -24,6 +25,10 @@ HDFC_REFUND_URL = f"{HDFC_BASE_URL}/v4/orders/{{order_id}}/refunds"
 
 HDFC_MERCHANT_ID = os.getenv("HDFC_MERCHANT_ID")
 HDFC_API_KEY = os.getenv("HDFC_API_KEY")
+if not HDFC_MERCHANT_ID:
+    raise ImproperlyConfigured("HDFC_MERCHANT_ID environment variable is required")
+if not HDFC_API_KEY:
+    raise ImproperlyConfigured("HDFC_API_KEY environment variable is required")
 HDFC_RETURN_URL= "https://iskcongorakhpur.com/payments/return"
 
 

--- a/iskcongkp/settings/production.py
+++ b/iskcongkp/settings/production.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 import os
 import os.path
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 # Load environment variables
 load_dotenv()
@@ -24,6 +25,10 @@ HDFC_REFUND_URL = f"{HDFC_BASE_URL}/v4/orders/{{order_id}}/refunds"
 
 HDFC_MERCHANT_ID = os.getenv("HDFC_MERCHANT_ID")
 HDFC_API_KEY = os.getenv("HDFC_API_KEY")
+if not HDFC_MERCHANT_ID:
+    raise ImproperlyConfigured("HDFC_MERCHANT_ID environment variable is required")
+if not HDFC_API_KEY:
+    raise ImproperlyConfigured("HDFC_API_KEY environment variable is required")
 HDFC_RETURN_URL= "https://iskcongorakhpur.com/payments/return"
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.


### PR DESCRIPTION
## Summary
- raise clear errors if HDFC credentials are missing in settings
- document required HDFC env vars for deployments

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement python-dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68b27af72824832d8fd440921c78bda5