### PR TITLE
Read HDFC key PEMs from files

### DIFF
--- a/iskcongkp/settings/base.py
+++ b/iskcongkp/settings/base.py
@@ -23,8 +23,31 @@ HDFC_SESSION_URL = f"{HDFC_BASE_URL}/v4/session"
 HDFC_ORDER_STATUS_URL = f"{HDFC_BASE_URL}/v4/orders/{{order_id}}"
 HDFC_REFUND_URL = f"{HDFC_BASE_URL}/v4/orders/{{order_id}}/refunds"
 HDFC_JWT_KID = os.getenv("HDFC_KEY_UUID")
-HDFC_MERCHANT_PRIVATE_KEY_PEM = os.getenv("HDFC_PRIVATE_KEY_PATH")
-HDFC_BANK_PUBLIC_KEY_PEM = os.getenv("HDFC_PUBLIC_KEY_PATH")
+
+# Load and validate merchant private key
+HDFC_PRIVATE_KEY_PATH = os.getenv("HDFC_PRIVATE_KEY_PATH")
+if not HDFC_PRIVATE_KEY_PATH:
+    raise ImproperlyConfigured("HDFC_PRIVATE_KEY_PATH environment variable is required")
+try:
+    with open(HDFC_PRIVATE_KEY_PATH, "r") as pk_file:
+        HDFC_MERCHANT_PRIVATE_KEY_PEM = pk_file.read()
+except OSError as exc:
+    raise ImproperlyConfigured(
+        f"Failed to read HDFC private key from {HDFC_PRIVATE_KEY_PATH}: {exc}"
+    )
+
+# Load and validate bank public key
+HDFC_PUBLIC_KEY_PATH = os.getenv("HDFC_PUBLIC_KEY_PATH")
+if not HDFC_PUBLIC_KEY_PATH:
+    raise ImproperlyConfigured("HDFC_PUBLIC_KEY_PATH environment variable is required")
+try:
+    with open(HDFC_PUBLIC_KEY_PATH, "r") as pub_file:
+        HDFC_BANK_PUBLIC_KEY_PEM = pub_file.read()
+except OSError as exc:
+    raise ImproperlyConfigured(
+        f"Failed to read HDFC public key from {HDFC_PUBLIC_KEY_PATH}: {exc}"
+    )
+
 HDFC_MERCHANT_ID = os.getenv("HDFC_MERCHANT_ID")
 HDFC_API_KEY = os.getenv("HDFC_API_KEY")
 if not HDFC_MERCHANT_ID:

--- a/iskcongkp/settings/production.py
+++ b/iskcongkp/settings/production.py
@@ -23,8 +23,31 @@ HDFC_SESSION_URL = f"{HDFC_BASE_URL}/v4/session"
 HDFC_ORDER_STATUS_URL = f"{HDFC_BASE_URL}/v4/orders/{{order_id}}"
 HDFC_REFUND_URL = f"{HDFC_BASE_URL}/v4/orders/{{order_id}}/refunds"
 HDFC_JWT_KID = os.getenv("HDFC_KEY_UUID")
-HDFC_MERCHANT_PRIVATE_KEY_PEM = os.getenv("HDFC_PRIVATE_KEY_PATH")
-HDFC_BANK_PUBLIC_KEY_PEM = os.getenv("HDFC_PUBLIC_KEY_PATH")
+
+# Load and validate merchant private key
+HDFC_PRIVATE_KEY_PATH = os.getenv("HDFC_PRIVATE_KEY_PATH")
+if not HDFC_PRIVATE_KEY_PATH:
+    raise ImproperlyConfigured("HDFC_PRIVATE_KEY_PATH environment variable is required")
+try:
+    with open(HDFC_PRIVATE_KEY_PATH, "r") as pk_file:
+        HDFC_MERCHANT_PRIVATE_KEY_PEM = pk_file.read()
+except OSError as exc:
+    raise ImproperlyConfigured(
+        f"Failed to read HDFC private key from {HDFC_PRIVATE_KEY_PATH}: {exc}"
+    )
+
+# Load and validate bank public key
+HDFC_PUBLIC_KEY_PATH = os.getenv("HDFC_PUBLIC_KEY_PATH")
+if not HDFC_PUBLIC_KEY_PATH:
+    raise ImproperlyConfigured("HDFC_PUBLIC_KEY_PATH environment variable is required")
+try:
+    with open(HDFC_PUBLIC_KEY_PATH, "r") as pub_file:
+        HDFC_BANK_PUBLIC_KEY_PEM = pub_file.read()
+except OSError as exc:
+    raise ImproperlyConfigured(
+        f"Failed to read HDFC public key from {HDFC_PUBLIC_KEY_PATH}: {exc}"
+    )
+
 HDFC_MERCHANT_ID = os.getenv("HDFC_MERCHANT_ID")
 HDFC_API_KEY = os.getenv("HDFC_API_KEY")
 if not HDFC_MERCHANT_ID:


### PR DESCRIPTION
## Summary
- read HDFC merchant and bank keys from file paths instead of using raw environment values
- raise clear ImproperlyConfigured errors when key paths are missing or unreadable

## Testing
- `python -m pytest` *(fails: AttributeError: 'object' object has no attribute 'DEFAULT_CHARSET')*


------
https://chatgpt.com/codex/tasks/task_e_68b289a22a80832dbfee0c3aecb7467e