### PR TITLE
Auto-generate usernames from first and last names

### DIFF
--- a/iskcongkp/forms.py
+++ b/iskcongkp/forms.py
@@ -1,7 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django.contrib.auth.models import User
-from django.core.exceptions import ValidationError
 
 
 class SignUpForm(UserCreationForm):
@@ -9,23 +8,44 @@ class SignUpForm(UserCreationForm):
 
     email = forms.EmailField(required=True)
     mobile = forms.CharField(required=True, max_length=15)
+    first_name = forms.CharField(required=True, max_length=150)
+    last_name = forms.CharField(required=True, max_length=150)
 
     class Meta:
         model = User
-        fields = ("username", "email", "mobile", "password1", "password2")
+        fields = (
+            "first_name",
+            "last_name",
+            "email",
+            "mobile",
+            "password1",
+            "password2",
+        )
         widgets = {
-            "username": forms.TextInput(attrs={"class": "form-control"}),
+            "first_name": forms.TextInput(attrs={"class": "form-control"}),
+            "last_name": forms.TextInput(attrs={"class": "form-control"}),
             "email": forms.EmailInput(attrs={"class": "form-control"}),
             "mobile": forms.TextInput(attrs={"class": "form-control"}),
             "password1": forms.PasswordInput(attrs={"class": "form-control"}),
             "password2": forms.PasswordInput(attrs={"class": "form-control"}),
         }
 
-    def clean_username(self):
-        username = self.cleaned_data.get("username")
-        if User.objects.filter(username=username).exists():
-            raise ValidationError("A user with that username already exists.")
-        return username
+    def save(self, commit=True):
+        """Create user with a unique username based on names."""
+        user = super().save(commit=False)
+        first = self.cleaned_data.get("first_name", "").strip().lower()
+        last = self.cleaned_data.get("last_name", "").strip().lower()
+        base_username = f"{first}.{last}"
+        username = base_username
+        counter = 1
+        while User.objects.filter(username=username).exists():
+            username = f"{base_username}{counter}"
+            counter += 1
+        user.username = username
+        if commit:
+            user.save()
+            self.save_m2m()
+        return user
 
 
 class SignInForm(AuthenticationForm):

--- a/iskcongkp/tests/test_signup_username.py
+++ b/iskcongkp/tests/test_signup_username.py
@@ -1,0 +1,53 @@
+from django.test import TestCase, override_settings
+
+from iskcongkp.forms import SignUpForm
+
+
+@override_settings(
+    DEBUG=False,
+    DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+)
+class UsernameGenerationTests(TestCase):
+    def test_incremental_usernames_generated(self):
+        form1 = SignUpForm(
+            data={
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john1@example.com",
+                "mobile": "1234567890",
+                "password1": "complexpass123",
+                "password2": "complexpass123",
+            }
+        )
+        self.assertTrue(form1.is_valid(), form1.errors)
+        user1 = form1.save()
+        self.assertEqual(user1.username, "john.doe")
+
+        form2 = SignUpForm(
+            data={
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john2@example.com",
+                "mobile": "1234567891",
+                "password1": "complexpass123",
+                "password2": "complexpass123",
+            }
+        )
+        self.assertTrue(form2.is_valid(), form2.errors)
+        user2 = form2.save()
+        self.assertEqual(user2.username, "john.doe1")
+
+        form3 = SignUpForm(
+            data={
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john3@example.com",
+                "mobile": "1234567892",
+                "password1": "complexpass123",
+                "password2": "complexpass123",
+            }
+        )
+        self.assertTrue(form3.is_valid(), form3.errors)
+        user3 = form3.save()
+        self.assertEqual(user3.username, "john.doe2")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ packaging==25.0
 pillow==11.1.0
 psycopg2-binary==2.9.10
 sqlparse==0.5.3
+python-dotenv==1.0.1

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -41,6 +41,7 @@
                                                                 <form method="post">
                                                                     {% csrf_token %}
                                                                     {{ form.as_p }}
+                                                                    <!-- first_name and last_name fields included; username is generated -->
                                                                     <button type="submit" class="btn btn-primary">Sign Up</button>
                                                                 </form>
                                                                 <p class="mt-3">Already have an account? <a href="{% url 'login' %}">Sign in</a>.</p>


### PR DESCRIPTION
## Summary
- remove username input from SignUpForm in favor of first/last name fields
- generate unique usernames from first and last names with numeric suffixes
- document new behaviour in sign up template and add tests

## Testing
- `python manage.py test` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b2e884b488832d9554681b102fe9f0