### PR TITLE
Allow sign-in with email or phone

### DIFF
--- a/iskcongkp/views.py
+++ b/iskcongkp/views.py
@@ -35,7 +35,7 @@ def signup_view(request):
 
 def signin_view(request):
     if request.method == "POST":
-        form = SignInForm(request, data=request.POST)
+        form = SignInForm(request.POST)
         if form.is_valid():
             login(request, form.get_user())
             return redirect("homepage:homepage")

--- a/templates/signin.html
+++ b/templates/signin.html
@@ -40,7 +40,21 @@
                                                             <div class="col-xs-12 col-sm-12 col-md-5" style="margin:0 auto;">
                                                                 <form method="post">
                                                                     {% csrf_token %}
-                                                                    {{ form.as_p }}
+                                                                    {{ form.non_field_errors }}
+                                                                    <div class="mb-3">
+                                                                        {{ form.identifier.label_tag }}
+                                                                        {{ form.identifier }}
+                                                                        {% for error in form.identifier.errors %}
+                                                                            <div class="text-danger">{{ error }}</div>
+                                                                        {% endfor %}
+                                                                    </div>
+                                                                    <div class="mb-3">
+                                                                        {{ form.password.label_tag }}
+                                                                        {{ form.password }}
+                                                                        {% for error in form.password.errors %}
+                                                                            <div class="text-danger">{{ error }}</div>
+                                                                        {% endfor %}
+                                                                    </div>
                                                                     <button type="submit" class="btn btn-primary">Sign In</button>
                                                                 </form>
                                                                 <p class="mt-3">Don't have an account? <a href="{% url 'signup' %}">Sign up</a>.</p>


### PR DESCRIPTION
## Summary
- Replace username login with identifier field supporting email or phone numbers.
- Authenticate users in form clean logic based on identifier type.
- Adjust sign-in view and template to use new identifier field.

## Testing
- `DJANGO_SETTINGS_MODULE=iskcongkp.settings.test python manage.py test iskcongkp.tests.test_error_handler iskcongkp.tests.test_signup_username`


------
https://chatgpt.com/codex/tasks/task_e_68b2ea01c030832daa8355e5a1a11b98