### PR TITLE
style: improve signup form layout

### DIFF
--- a/templates/signup.html
+++ b/templates/signup.html
@@ -4,6 +4,11 @@
 <head>
     {% include 'head.html' %}
     <title>Sign Up | ISKCON Gorakhpur</title>
+    <style>
+        .password-helptext {
+            font-size: 0.85rem;
+        }
+    </style>
 </head>
 <body class="layout-no-sidebars path-contact-usk node--type-page">
     <a href="#main-content" class="visually-hidden-focusable">
@@ -36,21 +41,70 @@
                                             <article role="article" class="node node--type-page node--view-mode-full clearfix">
                                                 <div class="node__content clearfix">
                                                     <div class="clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item">
-                                                        <div class="col-xs-12 col-sm-12 col-md-12" style="display:flex;flex-wrap:wrap;text-align:center;">
-                                                            <div class="col-xs-12 col-sm-12 col-md-5" style="margin:0 auto;">
-                                                                <form method="post">
+                                                        <div class="col-xs-12 col-sm-12 col-md-12" style="display:flex;flex-wrap:wrap;text-align:left;">
+                                                            <div class="col-xs-12 col-sm-12 col-md-5">
+                                                                <form method="post" class="text-start signup-form">
                                                                     {% csrf_token %}
-                                                                    {{ form.as_p }}
+                                                                    {{ form.non_field_errors }}
+                                                                    <div class="row">
+                                                                        <div class="col-md-6 mb-3">
+                                                                            {{ form.first_name.label_tag }}
+                                                                            {{ form.first_name }}
+                                                                            {% for error in form.first_name.errors %}
+                                                                                <div class="text-danger">{{ error }}</div>
+                                                                            {% endfor %}
+                                                                        </div>
+                                                                        <div class="col-md-6 mb-3">
+                                                                            {{ form.last_name.label_tag }}
+                                                                            {{ form.last_name }}
+                                                                            {% for error in form.last_name.errors %}
+                                                                                <div class="text-danger">{{ error }}</div>
+                                                                            {% endfor %}
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="row">
+                                                                        <div class="col-md-6 mb-3">
+                                                                            {{ form.email.label_tag }}
+                                                                            {{ form.email }}
+                                                                            {% for error in form.email.errors %}
+                                                                                <div class="text-danger">{{ error }}</div>
+                                                                            {% endfor %}
+                                                                        </div>
+                                                                        <div class="col-md-6 mb-3">
+                                                                            {{ form.mobile.label_tag }}
+                                                                            {{ form.mobile }}
+                                                                            {% for error in form.mobile.errors %}
+                                                                                <div class="text-danger">{{ error }}</div>
+                                                                            {% endfor %}
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="row">
+                                                                        <div class="col-md-6 mb-3">
+                                                                            {{ form.password1.label_tag }}
+                                                                            {{ form.password1 }}
+                                                                            {% for error in form.password1.errors %}
+                                                                                <div class="text-danger">{{ error }}</div>
+                                                                            {% endfor %}
+                                                                            <div class="text-muted password-helptext">{{ form.password1.help_text|safe }}</div>
+                                                                        </div>
+                                                                        <div class="col-md-6 mb-3">
+                                                                            {{ form.password2.label_tag }}
+                                                                            {{ form.password2 }}
+                                                                            {% for error in form.password2.errors %}
+                                                                                <div class="text-danger">{{ error }}</div>
+                                                                            {% endfor %}
+                                                                        </div>
+                                                                    </div>
                                                                     <!-- first_name and last_name fields included; username is generated -->
                                                                     <button type="submit" class="btn btn-primary">Sign Up</button>
                                                                 </form>
                                                                 <p class="mt-3">Already have an account? <a href="{% url 'login' %}">Sign in</a>.</p>
                                                             </div>
-                                                            <div class="col-xs-12 col-sm-12 col-md-5">
-                                                                <div class="align-right">
-                                                                    <div class="field field--name-field-media-image field--type-image field--label-visually_hidden">
-                                                                        <div class="field__item">
-                                                                            <picture>
+                                                        <div class="col-xs-12 col-sm-12 col-md-5">
+                                                            <div class="align-right">
+                                                                <div class="field field--name-field-media-image field--type-image field--label-visually_hidden">
+                                                                    <div class="field__item">
+                                                                        <picture>
                                                                                 <img src="{% static 'sites/krishna_help.png' %}" alt="Krishna Helping Devotees" />
                                                                             </picture>
                                                                         </div>


### PR DESCRIPTION
## Summary
- show signup fields in logical side-by-side rows
- left-align the signup form and shrink password help text

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-dotenv==1.0.1)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68b2ec03966c832d8dc418bfd599cb22