### PR TITLE
Poll payment status on thank-you page

### DIFF
--- a/templates/donations/thank_you.html
+++ b/templates/donations/thank_you.html
@@ -1,3 +1,11 @@
 <h2>Hare Krishna 🙏</h2>
-<p>Thank you! Your payment status will be confirmed by email within a few seconds.</p>
+{% if server_checked %}
+  {% if is_paid %}
+    <p>Your donation was successful. Thank you!</p>
+  {% else %}
+    <p>Your payment status is: {{ status|default:"PENDING" }}</p>
+  {% endif %}
+{% else %}
+  <p>Thank you! Your payment status will be confirmed by email within a few seconds.</p>
+{% endif %}
 <p>You may close this window.</p>


### PR DESCRIPTION
## Summary
- Poll HDFC gateway for final donation status on thank-you view
- Mark donations paid when gateway reports success and show result to donor
- Display reconciled payment status on thank-you template

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68b4c4ebf71c832da7231ed20fc6a609