### PR TITLE
fix(donations): replace shorter donor names

### DIFF
--- a/donations/services.py
+++ b/donations/services.py
@@ -36,7 +36,7 @@ def get_or_create_donor(name: str, email: str | None, phone: str | None, pan: st
             donor.phone_e164 = phone_e164; changed = True
         if not donor.pan and pan_norm:
             donor.pan = pan_norm; changed = True
-        if name and (not donor.name or len(name) < len(name)):
+        if name and (not donor.name or len(donor.name) < len(name)):
             donor.name = name; changed = True
         if addr:
             for f,v in addr.items():

--- a/donations/tests.py
+++ b/donations/tests.py
@@ -1,3 +1,22 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Donor
+from .services import get_or_create_donor
+
+
+class GetOrCreateDonorTests(TestCase):
+    def test_longer_name_updates_donor(self):
+        donor = Donor.objects.create(name="Bob", email="bob@example.com", email_norm="bob@example.com")
+
+        get_or_create_donor("Robert", "bob@example.com", None, None)
+        donor.refresh_from_db()
+
+        self.assertEqual(donor.name, "Robert")
+
+    def test_shorter_name_does_not_override(self):
+        donor = Donor.objects.create(name="Robert", email="bob@example.com", email_norm="bob@example.com")
+
+        get_or_create_donor("Bob", "bob@example.com", None, None)
+        donor.refresh_from_db()
+
+        self.assertEqual(donor.name, "Robert")


### PR DESCRIPTION
## Summary
- ensure donors update their name only when new name is longer
- add tests for updating donors with longer names

## Testing
- `ENVIRONMENT_NAME=test python manage.py test` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68b4c6d76538832db5c7794d4ea337c1