### PR TITLE
Support gateway txn ID lookup via order_id

### DIFF
--- a/donations/test_webhook.py
+++ b/donations/test_webhook.py
@@ -1,0 +1,49 @@
+import json
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from .models import Donor, Donation
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class HdfcWebhookTests(TestCase):
+    def setUp(self):
+        self.donor = Donor.objects.create(
+            email='alice@example.com',
+            email_norm='alice@example.com'
+        )
+
+    def _post(self, payload: dict):
+        return self.client.post(
+            reverse('donations:hdfc_webhook'),
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+    def test_transaction_id_matches_txn_id(self):
+        donation = Donation.objects.create(
+            donor=self.donor,
+            amount=100,
+            purpose='Test',
+            txn_id='TXN123',
+            order_id='ORD999',
+        )
+        payload = {'transaction': {'id': 'TXN123', 'status': 'SUCCESS'}}
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        donation.refresh_from_db()
+        self.assertEqual(donation.status, 'SUCCESS')
+
+    def test_transaction_id_matches_order_id(self):
+        donation = Donation.objects.create(
+            donor=self.donor,
+            amount=100,
+            purpose='Test',
+            txn_id='INT123',
+            order_id='GW456',
+        )
+        payload = {'transaction': {'id': 'GW456', 'status': 'SUCCESS'}}
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        donation.refresh_from_db()
+        self.assertEqual(donation.status, 'SUCCESS')

--- a/donations/webhook.py
+++ b/donations/webhook.py
@@ -65,13 +65,15 @@ def hdfc_webhook(request):
     # Resolve donation robustly:
     # 1) If gateway sent back our order_id (which we set to our txn_id), match on Donation.txn_id == gw_order_id
     # 2) Else, if we stored the gateway order/session id on Donation.order_id, match on that
-    # 3) Else, try matching on the gateway transaction id to Donation.txn_id (legacy/alternate maps)
+    # 3) Else, try matching on the gateway transaction id to Donation.txn_id
+    #    or Donation.order_id (legacy/alternate maps)
     donation = None
     if gw_order_id:
         donation = Donation.objects.filter(txn_id=gw_order_id).first() or \
                    Donation.objects.filter(order_id=gw_order_id).first()
     if donation is None and gw_txn_id:
-        donation = Donation.objects.filter(txn_id=gw_txn_id).first()
+        donation = Donation.objects.filter(txn_id=gw_txn_id).first() or \
+                   Donation.objects.filter(order_id=gw_txn_id).first()
     if donation is None:
         return HttpResponse("unknown order", status=202)
 


### PR DESCRIPTION
## Summary
- handle webhook gateway `transaction.id` by also checking `Donation.order_id`
- test webhook resolution when payload only sends `transaction.id`

## Testing
- `PYTHONPATH=/tmp ENVIRONMENT_NAME=test python manage.py test donations -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b4c8410f58832d818a3c16f365f1b6