### PR TITLE
feat(payments): add Easebuzz integration endpoints and wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,8 @@ gunicorn iskcongkp.wsgi
 
 Static files are served from the `assets/` directory and media uploads from `media/`.
 
+
+## Payment gateway integration
+
+Easebuzz integration endpoints are available under `/payments/easebuzz/*`.
+See `docs/easebuzz_integration_steps.md` for setup (`easebuzz_lib` copy, env vars, payload format, and callbacks).

--- a/docs/easebuzz_integration_steps.md
+++ b/docs/easebuzz_integration_steps.md
@@ -1,0 +1,94 @@
+# Easebuzz Payment Gateway Integration (Implemented in this project)
+
+This repository now includes Easebuzz integration endpoints under the `payments` app.
+
+## 1) Add Easebuzz SDK library
+
+Copy `easebuzz_lib/` to the project root (same folder level as `manage.py`), as provided in Easebuzz's Django kit.
+
+Expected import used by code:
+
+```python
+from easebuzz_lib.easebuzz_payment_gateway import Easebuzz
+```
+
+> If this folder is not present, the new API endpoints will return a clear error that `easebuzz_lib` is missing.
+
+## 2) Configure environment variables
+
+Set these in your `.env`:
+
+```ini
+EASEBUZZ_MERCHANT_KEY=your_merchant_key
+EASEBUZZ_SALT=your_salt
+EASEBUZZ_ENV=test
+```
+
+- Use `test` for UAT
+- Switch to `prod` only after UAT sign-off
+
+## 3) Start Django server
+
+```bash
+python manage.py runserver
+```
+
+## 4) Initiate payment from your frontend/backend client
+
+Endpoint:
+
+- `POST /payments/easebuzz/initiate`
+
+Required JSON fields:
+
+- `firstname`
+- `phone`
+- `email`
+- `amount`
+- `productinfo`
+
+Optional:
+
+- `txnid` (auto-generated if omitted)
+- `surl`, `furl` (defaults to `/payments/easebuzz/response`)
+- `city`, `zipcode`, `address1`, `address2`, `state`, `country`, `udf1..udf5`
+
+Example payload:
+
+```json
+{
+  "firstname": "Jitendra",
+  "phone": "9999999999",
+  "email": "jitendra@example.com",
+  "amount": "1.03",
+  "productinfo": "Apple Mobile"
+}
+```
+
+Success response includes `payment_url` for redirect:
+
+```json
+{
+  "ok": true,
+  "txnid": "EZB...",
+  "payment_url": "https://..."
+}
+```
+
+## 5) Handle Easebuzz gateway callback
+
+Endpoint already added:
+
+- `POST /payments/easebuzz/response`
+
+Set this URL in Easebuzz (`surl`/`furl`) or pass custom callback URLs while initiating payment.
+
+The endpoint parses posted form data through Easebuzz SDK response helper and returns JSON.
+
+## 6) Production checklist
+
+1. Keep `EASEBUZZ_ENV=test` until all cases pass.
+2. Ensure callback URLs are HTTPS and publicly reachable.
+3. Move to `EASEBUZZ_ENV=prod` with production key/salt.
+4. Persist payment outcomes in your business models before fulfillment.
+5. Add reconciliation jobs (transaction/refund APIs) if required by your ops flow.

--- a/payments/integrations/easebuzz.py
+++ b/payments/integrations/easebuzz.py
@@ -1,0 +1,45 @@
+import json
+import os
+from typing import Any, Dict, Mapping
+
+try:
+    from easebuzz_lib.easebuzz_payment_gateway import Easebuzz
+except Exception:  # library is optional until integrator adds it
+    Easebuzz = None
+
+
+class EasebuzzIntegrationError(Exception):
+    pass
+
+
+def _credentials() -> tuple[str, str, str]:
+    merchant_key = os.getenv("EASEBUZZ_MERCHANT_KEY", "")
+    salt = os.getenv("EASEBUZZ_SALT", "")
+    env = os.getenv("EASEBUZZ_ENV", "test")
+    if not merchant_key or not salt:
+        raise EasebuzzIntegrationError("Missing EASEBUZZ_MERCHANT_KEY or EASEBUZZ_SALT")
+    if env not in {"test", "prod"}:
+        raise EasebuzzIntegrationError("EASEBUZZ_ENV must be either 'test' or 'prod'")
+    return merchant_key, salt, env
+
+
+def _client():
+    if Easebuzz is None:
+        raise EasebuzzIntegrationError(
+            "easebuzz_lib is not installed. Copy easebuzz_lib into project root as per integration guide."
+        )
+    merchant_key, salt, env = _credentials()
+    return Easebuzz(merchant_key, salt, env)
+
+
+def initiate_payment(post_data: Mapping[str, Any]) -> Dict[str, Any]:
+    response = _client().initiatePaymentAPI(dict(post_data))
+    if isinstance(response, str):
+        return json.loads(response)
+    if isinstance(response, dict):
+        return response
+    raise EasebuzzIntegrationError("Unexpected response type from initiatePaymentAPI")
+
+
+def parse_gateway_response(post_data: Mapping[str, Any]) -> Any:
+    return _client().easebuzzResponse(dict(post_data))

--- a/payments/integrations/hdfc.py
+++ b/payments/integrations/hdfc.py
@@ -3,8 +3,14 @@ load_dotenv()
 
 import os, re, json, base64
 from decimal import Decimal, ROUND_HALF_UP
-import requests
-from requests import RequestException
+try:
+    import requests
+    from requests import RequestException
+except Exception:
+    requests = None
+
+    class RequestException(Exception):
+        pass
 
 HDFC_BASE_URL    = os.getenv("HDFC_BASE_URL", "https://smartgateway.hdfcbank.com")
 HDFC_API_KEY     = os.getenv("HDFC_API_KEY", "")
@@ -44,6 +50,8 @@ def _amount_str(amount) -> str:
 
 def create_session(*, order_id, amount, customer_id, customer_email, customer_phone,
                    first_name="", last_name="", description="", currency="INR") -> dict:
+    if requests is None:
+        raise HdfcError("Missing requests dependency. Install from requirements.txt")
     if not HDFC_MERCHANT_ID: raise HdfcError("Missing HDFC_MERCHANT_ID")
     if not HDFC_RETURN_URL or not HDFC_RETURN_URL.startswith("https://") or "?" in HDFC_RETURN_URL:
         raise HdfcError("Invalid HDFC_RETURN_URL (must be HTTPS, no query params)")
@@ -76,6 +84,8 @@ def create_session(*, order_id, amount, customer_id, customer_email, customer_ph
     raise HdfcError(f"Create session failed: {hint}. Response: {json.dumps(data)[:800]}")
 
 def get_order_status(order_id: str, customer_id: str) -> dict:
+    if requests is None:
+        raise HdfcError("Missing requests dependency. Install from requirements.txt")
     url = f"{HDFC_BASE_URL}/orders/{_sanitize_order_id(order_id)}"
     try:
         resp = requests.get(url, headers=_headers(customer_id), timeout=30)

--- a/payments/tests.py
+++ b/payments/tests.py
@@ -24,3 +24,26 @@ class PaymentStatusExtractionTests(unittest.TestCase):
         self.assertEqual(status, "CANCELED")
         self.assertEqual(category, "failed")
         self.assertEqual(source, "payment.order_status")
+
+from unittest.mock import patch
+from payments.integrations.easebuzz import _credentials, EasebuzzIntegrationError
+
+
+class EasebuzzIntegrationConfigTests(unittest.TestCase):
+    def test_credentials_require_key_and_salt(self):
+        with patch.dict("os.environ", {}, clear=False):
+            with self.assertRaises(EasebuzzIntegrationError):
+                _credentials()
+
+    def test_invalid_env_is_rejected(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "EASEBUZZ_MERCHANT_KEY": "k",
+                "EASEBUZZ_SALT": "s",
+                "EASEBUZZ_ENV": "staging",
+            },
+            clear=False,
+        ):
+            with self.assertRaises(EasebuzzIntegrationError):
+                _credentials()

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 from . import views
 app_name = "payments"
 urlpatterns = [
+    path("easebuzz/initiate", views.easebuzz_initiate_view, name="easebuzz_initiate"),
+    path("easebuzz/response", views.easebuzz_response_view, name="easebuzz_response"),
     path("test", views.hdfc_test_page_view, name="hdfc_test"),
     path("my", views.my_payments_view, name="my_payments"),
     path("sign-session", views.hdfc_sign_session_view, name="hdfc_sign_session"),

--- a/payments/views.py
+++ b/payments/views.py
@@ -1,6 +1,7 @@
 import json
 from django.http import JsonResponse, HttpResponseBadRequest
 from django.shortcuts import render
+from django.urls import reverse
 from django.views.decorators.http import require_POST, require_GET
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
@@ -8,6 +9,7 @@ from django.utils.dateparse import parse_datetime
 from datetime import timezone
 
 from .integrations.hdfc import create_session, get_order_status, HdfcError, _sanitize_order_id
+from .integrations.easebuzz import initiate_payment, parse_gateway_response, EasebuzzIntegrationError
 from django.utils.crypto import get_random_string
 from .emails import send_payment_confirmation
 from .models import Order
@@ -19,6 +21,71 @@ from .utils import extract_payment_status, SUCCESS_STATUSES, PENDING_STATUSES
 def _json_body(request):
     try: return json.loads(request.body.decode("utf-8"))
     except Exception: return None
+
+
+
+@csrf_protect
+@login_required
+@require_POST
+def easebuzz_initiate_view(request):
+    body = _json_body(request)
+    if not body:
+        return HttpResponseBadRequest("Invalid JSON body")
+
+    required = ["firstname", "phone", "email", "amount", "productinfo"]
+    missing = [k for k in required if not body.get(k)]
+    if missing:
+        return HttpResponseBadRequest(f"Missing fields: {', '.join(missing)}")
+
+    txnid = str(body.get("txnid") or generate_order_id(prefix="EZB"))
+    response_url = request.build_absolute_uri(reverse("payments:easebuzz_response"))
+
+    post_data = {
+        "txnid": txnid,
+        "firstname": body["firstname"],
+        "phone": body["phone"],
+        "email": body["email"],
+        "amount": str(body["amount"]),
+        "productinfo": body["productinfo"],
+        "surl": body.get("surl") or response_url,
+        "furl": body.get("furl") or response_url,
+        "city": body.get("city", ""),
+        "zipcode": body.get("zipcode", ""),
+        "address2": body.get("address2", ""),
+        "state": body.get("state", ""),
+        "address1": body.get("address1", ""),
+        "country": body.get("country", ""),
+        "udf1": body.get("udf1", ""),
+        "udf2": body.get("udf2", ""),
+        "udf3": body.get("udf3", ""),
+        "udf4": body.get("udf4", ""),
+        "udf5": body.get("udf5", ""),
+    }
+
+    try:
+        result = initiate_payment(post_data)
+    except EasebuzzIntegrationError as e:
+        return JsonResponse({"ok": False, "error": str(e)}, status=400)
+    except Exception as e:
+        return JsonResponse({"ok": False, "error": f"Easebuzz request failed: {str(e)}"}, status=500)
+
+    status = result.get("status")
+    payment_url = result.get("data")
+    if status == 1 and payment_url:
+        return JsonResponse({"ok": True, "txnid": txnid, "payment_url": payment_url, "result": result})
+    return JsonResponse({"ok": False, "txnid": txnid, "result": result}, status=400)
+
+
+@csrf_exempt
+@require_POST
+def easebuzz_response_view(request):
+    try:
+        final_response = parse_gateway_response(request.POST)
+        return JsonResponse({"ok": True, "response_data": final_response})
+    except EasebuzzIntegrationError as e:
+        return JsonResponse({"ok": False, "error": str(e)}, status=400)
+    except Exception as e:
+        return JsonResponse({"ok": False, "error": f"Could not parse Easebuzz response: {str(e)}"}, status=500)
 
 def hdfc_test_page_view(request):
     """Render a simple test page to initiate an HDFC payment session.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pillow==11.1.0
 psycopg2-binary==2.9.10
 sqlparse==0.5.3
 python-dotenv==1.0.1
+requests==2.32.3


### PR DESCRIPTION
### Motivation
- Provide a first-class Easebuzz payment integration inside the `payments` app so the project can initiate Easebuzz payments and handle callbacks using a small, testable wrapper. 
- Avoid startup-time failures when optional runtime dependencies (SDK or `requests`) are missing and surface clear errors only when gateway functions are invoked. 

### Description
- Added `payments/integrations/easebuzz.py` which loads credentials from `EASEBUZZ_MERCHANT_KEY`, `EASEBUZZ_SALT`, and `EASEBUZZ_ENV`, initializes the Easebuzz SDK, normalizes `initiatePaymentAPI` responses, and exposes a parser for gateway callbacks. 
- Added two endpoints: `POST /payments/easebuzz/initiate` (`easebuzz_initiate_view`) and `POST /payments/easebuzz/response` (`easebuzz_response_view`) and wired them in `payments/urls.py`, with request validation, auto-`txnid` generation, and JSON success/error outputs. 
- Updated `payments/integrations/hdfc.py` to import `requests` defensively (make it optional at import-time) and raise `HdfcError` at runtime if network functions are called without the dependency, preventing Django startup checks from failing. 
- Added `docs/easebuzz_integration_steps.md` and updated `README.md` to document the endpoints and required setup, and added `requests==2.32.3` to `requirements.txt` to declare the HTTP dependency. 
- Added unit tests in `payments/tests.py` for Easebuzz credential validation behavior (`missing key/salt` and invalid `EASEBUZZ_ENV`). 

### Testing
- Ran unit tests with `python -m unittest payments.tests`, which passed (all tests OK). 
- Ran `python manage.py check`, which reported no issues. 
- Attempted `pip install -r requirements.txt` but the environment could not fetch `requests==2.32.3` due to a network/proxy restriction, however code now handles missing `requests` gracefully and raises clear runtime errors when gateway methods are invoked. 
- Ran `git diff --check` which passed with no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5e54f630832dbb3728921becf85e)